### PR TITLE
fix: Broken "About" link

### DIFF
--- a/common/footer.html
+++ b/common/footer.html
@@ -209,7 +209,7 @@
           <a class="small-link posting-guidelines" href="/guidelines">
             Posting guidelines
           </a>
-          <a class="small-link about-us" href="https://www.privacyguides.org/about/">
+          <a class="small-link about-us" href="https://www.privacyguides.org/en/about/">
             About us
           </a>
           <a class="small-link forum-design-by-jonah" href="https://www.jonaharagon.com/">


### PR DESCRIPTION
Change proposed in this PR:

- Fix broken "About" link at the footer of the Discourse forum

Semi-relatedly, a community member reported another broken link on one of the forum pages, but I couldn't find the place to contribute a fix for that: https://discuss.privacyguides.net/t/about-page-contains-a-non-functional-link/20489